### PR TITLE
Made rules clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 3. You can sign up anytime between `October 1` and `October 31`.
 
 ## Rules:
-To earn your **`Hacktoberfest T-Shirt`** or tree reward, you must register and make four valid pull requests (PRs) between `October 1-31` (in any time zone). PRs can be made to any public repo on GitHub, not only the ones with issues labeled **`Hacktoberfest`**. If a `maintainer` reports your pull request as `spam` or behavior not in line with the project’s code of conduct, you will be `ineligible` to participate. This year, the first **`70,000`** participants who successfully complete the challenge will be eligible to receive a `prize`.
+To earn your **`Hacktoberfest T-Shirt`** or tree reward, you must register and make four valid pull requests (PRs) between `October 1-31` (in any time zone). PRs can **NOT** be made to any public repo on GitHub, maintainers have to opt in with the topic **`Hacktoberfest`** on the repo. If a `maintainer` reports your pull request as `spam` or behavior not in line with the project’s code of conduct, you will be `ineligible` to participate. This year, the first **`70,000`** participants who successfully complete the challenge will be eligible to receive a `prize`.
 
 ## Projects in which you can contribute:
-- Any `github` repository 
+- Any `github` repository with the **`Hacktoberfest`** topic
 - For the sake of convinience, you can contribute to this very project :)
 
 ## Getting started with git:


### PR DESCRIPTION
This year repos have to have the topic "hacktoberfest" to participate.
Source: https://hacktoberfest.digitalocean.com/hacktoberfest-update

Don't think they have updated their FAQ from this.